### PR TITLE
Add Jest and basic utility tests

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,3 @@
+export default {
+  testEnvironment: 'node'
+};

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "jest"
   },
   "dependencies": {
     "@emailjs/browser": "^3.10.0",
@@ -28,6 +29,7 @@
     "autoprefixer": "^10.4.13",
     "postcss": "^8.4.21",
     "tailwindcss": "^3.2.6",
-    "vite": "^4.1.0"
+    "vite": "^4.1.0",
+    "jest": "^29.6.1"
   }
 }

--- a/src/utils/__tests__/motion.test.js
+++ b/src/utils/__tests__/motion.test.js
@@ -1,0 +1,28 @@
+import { textVariant, fadeIn } from '../motion.js';
+
+describe('motion utilities', () => {
+  test('textVariant returns expected structure', () => {
+    const result = textVariant(0.5);
+    expect(result).toEqual({
+      hidden: { y: -50, opacity: 0 },
+      show: {
+        y: 0,
+        opacity: 1,
+        transition: { type: 'spring', duration: 1.25, delay: 0.5 }
+      }
+    });
+  });
+
+  test('fadeIn returns expected structure', () => {
+    const result = fadeIn('left', 'tween', 0.3, 1);
+    expect(result).toEqual({
+      hidden: { x: 100, y: 0, opacity: 0 },
+      show: {
+        x: 0,
+        y: 0,
+        opacity: 1,
+        transition: { type: 'tween', delay: 0.3, duration: 1, ease: 'easeOut' }
+      }
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add Jest dev dependency and config
- test `textVariant` and `fadeIn`
- expose `npm test` script

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685940a93e7c832290c0d5b7b3fa2931